### PR TITLE
Fix argument inputs, use deployment stacks, fix dependency checks, add bicepparams files

### DIFF
--- a/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-dns.bicepparam
+++ b/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-dns.bicepparam
@@ -1,0 +1,24 @@
+using 'cloud-nss-dns.bicep'
+
+// Define the 'param' values below
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
+param resourceGroup = 'xxx'
+
+// The name of your Log Analytics workspace
+param workspaceName = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> JSON View -> "location": (i.e. useast)
+param location = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID
+param subscriptionId = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID
+param workspaceId = 'xxx'
+
+// The name you want to provide the Data Collection Endpoint that the template will create
+param dceName = 'xxx'
+
+// The name you want to provide the Data Collection Rule that the template will create
+param dcrName = 'xxx'

--- a/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-fw.bicep
+++ b/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-fw.bicep
@@ -1,20 +1,45 @@
-// This creates both the DCR and DCE's needed to ingest data into Sentinel from Zscaler's Cloud NSS capability.
-// Steps needed to deploy
-// 1. Create an App Registration as per the DG/Storylane demo
-// 2. To run this script install bicep (if not already installed) and run the following command - New-AzResourceGroupDeployment -ResourceGroupName "<resource group containing your log analytics workspace>" -TemplateFile "cloud-nss-fw.bicep"
-// 3. Go to the DCR this bicep template creates -> IAM -> Add this DCR as a Monitoring Metrics Publisher for the App Registration you created create.
-// 4. Configure your Cloud NSS feed in the Zscaler Portal.
+/* 
+This creates both the DCR and DCE's needed to ingest data into Sentinel from Zscaler's Cloud NSS capability.
+Steps needed to deploy:
+1. Create an App Registration as per the Deployment Guide or Storylane demo
+2. Run this script from Azure CLI using the following command:
+
+  az stack group create --name cloud-nss-fw --resource-group <resource group containing your log analytics workspace> --template-file ./cloud-nss-fw.bicep --deny-settings-mode 'none'
+
+  You will be prompted for parameters such as the resource group name and workspace id. You can enter ? and press enter to get a description of where to find each item.
+  
+  Alternatively, you can specify these parameters ahead of time by populating the cloud-nss-web.bicepparams file and running the following command in Azure CLI to deploy:
+
+  az stack group create --name cloud-nss-fw --resource-group <resource group containing your log analytics workspace> --parameters cloud-nss-web.bicepparam --deny-settings-mode 'none'
+
+3. Go to the DCR this bicep template creates -> IAM -> Add this DCR as a Monitoring Metrics Publisher for the App Registration you created earlier.
+4. Configure your Cloud NSS feed in the Zscaler Portal. You can retrieve the feed API URL using the following command in Azure CLI:
+
+   az stack group show -g <resouce group containing your log analytics workspace> -n cloud-nss-fw --query outputs.api_url
+
+5. If you ever need to delete the deployment, you can run the following command from Azure CLI:
+
+  az stack group delete --name cloud-nss-fw --resource-group <resouce group containing your log analytics workspace> --delete-resources
+
+*/
 
 // These resources need to be pre-configured
-param resoureGroup string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
-param workspaceName string = 'xxx' // The name of your Log Analytics workspace
-param location string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Location. I.e. 'australiaeast' (no spaces)
-param subscriptionId string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID
-param workspaceId string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> Resource group')
+param resourceGroup string // Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
+@description('The name of your Log Analytics workspace')
+param workspaceName string
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> JSON View -> location. I.e. australiaeast')
+param location string
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID')
+param subscriptionId string
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID')
+param workspaceId string
 
 // These resources are configured through bicep
-param dceName string = 'xxx'
-param dcrName string = 'xxx'
+@description('Name of Data Collection Endpoint the template will create')
+param dceName string
+@description('Name of the Data Collection Rule the template will create')
+param dcrName string
 
 resource dce 'Microsoft.Insights/dataCollectionEndpoints@2022-06-01' = {
   properties: {
@@ -29,11 +54,8 @@ resource dce 'Microsoft.Insights/dataCollectionEndpoints@2022-06-01' = {
 }
 
 resource dcr 'Microsoft.Insights/dataCollectionRules@2022-06-01' = {
-  dependsOn: [
-    dce // This line ensures dcr creation waits for dce to be fully deployed
-  ]
   properties: {
-    dataCollectionEndpointId: '/subscriptions/${subscriptionId}/resourceGroups/${resoureGroup}/providers/Microsoft.Insights/dataCollectionEndpoints/${dceName}'
+    dataCollectionEndpointId: dce.id
     streamDeclarations: {
       'Custom-nss_fw_CL': {
         columns: [
@@ -232,7 +254,7 @@ resource dcr 'Microsoft.Insights/dataCollectionRules@2022-06-01' = {
     destinations: {
       logAnalytics: [
         {
-          workspaceResourceId: '/subscriptions/${subscriptionId}/resourcegroups/${resoureGroup}/providers/microsoft.operationalinsights/workspaces/${workspaceName}'
+          workspaceResourceId: resourceId(subscriptionId, resourceGroup, 'microsoft.operationalinsights/workspaces', workspaceName)
           name: workspaceId
         }
       ]
@@ -253,3 +275,6 @@ resource dcr 'Microsoft.Insights/dataCollectionRules@2022-06-01' = {
   location: location
   name: dcrName
 }
+
+// Store feed api url in template output
+output api_url string = '${dce.properties.logsIngestion.endpoint}/dataCollectionRules/${dcr.properties.immutableId}/streams/Custom-nss_fw_CL?api-version=2022-06-01'

--- a/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-fw.bicepparam
+++ b/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-fw.bicepparam
@@ -1,0 +1,24 @@
+using 'cloud-nss-fw.bicep'
+
+// Define the 'param' values below
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
+param resourceGroup = 'xxx'
+
+// The name of your Log Analytics workspace
+param workspaceName = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> JSON View -> "location": (i.e. useast)
+param location = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID
+param subscriptionId = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID
+param workspaceId = 'xxx'
+
+// The name you want to provide the Data Collection Endpoint that the template will create
+param dceName = 'xxx'
+
+// The name you want to provide the Data Collection Rule that the template will create
+param dcrName = 'xxx'

--- a/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-web.bicep
+++ b/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-web.bicep
@@ -1,20 +1,45 @@
-// This creates both the DCR and DCE's needed to ingest data into Sentinel from Zscaler's Cloud NSS capability.
-// Steps needed to deploy
-// 1. Create an App Registration as per the DG/Storylane demo
-// 2. To run this script install bicep (if not already installed) and run the following command - New-AzResourceGroupDeployment -ResourceGroupName "<resource group containing your log analytics workspace>" -TemplateFile "cloud-nss-web.bicep"
-// 3. Go to the DCR this bicep template creates -> IAM -> Add this DCR as a Monitoring Metrics Publisher for the App Registration you created create.
-// 4. Configure your Cloud NSS feed in the Zscaler Portal.
+/* 
+This creates both the DCR and DCE's needed to ingest data into Sentinel from Zscaler's Cloud NSS capability.
+Steps needed to deploy:
+1. Create an App Registration as per the Deployment Guide or Storylane demo
+2. Run this script from Azure CLI using the following command:
+
+  az stack group create --name cloud-nss-web --resource-group <resource group containing your log analytics workspace> --template-file ./cloud-nss-web.bicep --deny-settings-mode 'none'
+
+  You will be prompted for parameters such as the resource group name and workspace id. You can enter ? and press enter to get a description of where to find each item.
+  
+  Alternatively, you can specify these parameters ahead of time by populating the cloud-nss-web.bicepparams file and running the following command in Azure CLI to deploy:
+
+  az stack group create --name cloud-nss-web --resource-group <resource group containing your log analytics workspace> --parameters cloud-nss-web.bicepparam --deny-settings-mode 'none'
+
+3. Go to the DCR this bicep template creates -> IAM -> Add this DCR as a Monitoring Metrics Publisher for the App Registration you created earlier.
+4. Configure your Cloud NSS feed in the Zscaler Portal. You can retrieve the feed API URL using the following command in Azure CLI:
+
+   az stack group show -g <resouce group containing your log analytics workspace> -n cloud-nss-web --query outputs.api_url
+
+5. If you ever need to delete the deployment, you can run the following command from Azure CLI:
+
+  az stack group delete --name cloud-nss-web --resource-group <resouce group containing your log analytics workspace> --delete-resources
+
+*/
 
 // These resources need to be pre-configured
-param resoureGroup string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
-param workspaceName string = 'xxx' // The name of your Log Analytics workspace
-param location string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Location. I.e. 'australiaeast' (no spaces)
-param subscriptionId string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID
-param workspaceId string = 'xxx' // Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> Resource group')
+param resourceGroup string // Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
+@description('The name of your Log Analytics workspace')
+param workspaceName string
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> JSON View -> location. I.e. australiaeast')
+param location string
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID')
+param subscriptionId string
+@description('Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID')
+param workspaceId string
 
 // These resources are configured through bicep
-param dceName string = 'xxx'
-param dcrName string = 'xxx'
+@description('Name of Data Collection Endpoint the template will create')
+param dceName string
+@description('Name of the Data Collection Rule the template will create')
+param dcrName string
 
 resource dce 'Microsoft.Insights/dataCollectionEndpoints@2022-06-01' = {
   properties: {
@@ -29,11 +54,8 @@ resource dce 'Microsoft.Insights/dataCollectionEndpoints@2022-06-01' = {
 }
 
 resource dcr 'Microsoft.Insights/dataCollectionRules@2022-06-01' = {
-  dependsOn: [
-    dce // This line ensures dcr creation waits for dce to be fully deployed
-  ]
   properties: {
-    dataCollectionEndpointId: '/subscriptions/${subscriptionId}/resourceGroups/${resoureGroup}/providers/Microsoft.Insights/dataCollectionEndpoints/${dceName}'
+    dataCollectionEndpointId: dce.id
     streamDeclarations: {
       'Custom-nss_web_CL': {
         columns: [
@@ -232,7 +254,7 @@ resource dcr 'Microsoft.Insights/dataCollectionRules@2022-06-01' = {
     destinations: {
       logAnalytics: [
         {
-          workspaceResourceId: '/subscriptions/${subscriptionId}/resourcegroups/${resoureGroup}/providers/microsoft.operationalinsights/workspaces/${workspaceName}'
+          workspaceResourceId: resourceId(subscriptionId, resourceGroup, 'microsoft.operationalinsights/workspaces', workspaceName)
           name: workspaceId
         }
       ]
@@ -253,3 +275,6 @@ resource dcr 'Microsoft.Insights/dataCollectionRules@2022-06-01' = {
   location: location
   name: dcrName
 }
+
+// Store feed api url in template output
+output api_url string = '${dce.properties.logsIngestion.endpoint}/dataCollectionRules/${dcr.properties.immutableId}/streams/Custom-nss_web_CL?api-version=2022-06-01'

--- a/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-web.bicepparam
+++ b/demo-resources/configuring-microsoft-sentinel-for-cloud-nss-based-log-ingestion/bicep-templates/cloud-nss-web.bicepparam
@@ -1,0 +1,24 @@
+using 'cloud-nss-web.bicep'
+
+// Define the 'param' values below
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Resource group
+param resourceGroup = 'xxx'
+
+// The name of your Log Analytics workspace
+param workspaceName = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> JSON View -> "location": (i.e. useast)
+param location = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Subscription ID
+param subscriptionId = 'xxx'
+
+// Found under Log Analytics workspace -> your workspace -> Overview -> Workspace ID
+param workspaceId = 'xxx'
+
+// The name you want to provide the Data Collection Endpoint that the template will create
+param dceName = 'xxx'
+
+// The name you want to provide the Data Collection Rule that the template will create
+param dcrName = 'xxx'


### PR DESCRIPTION
Modified the templates to be useable either interactively with inline help and descriptions of each input, e.g.

Please provide string value for 'dceName' (? for help): ?
Name of Data Collection Endpoint the template will create
Please provide string value for 'dceName' (? for help): genetest-dce
Please provide string value for 'dcrName' (? for help): ?
Name of the Data Collection Rule the template will create

or pre-populated via a .bicepparam file. This is cleaner and avoids having users edit the bicep template or have conflicts if we update the template in the future.

The deployment instructions in the comments have also been updated for Azure CLI and with the 'az stack group' command to take advantage of deployment stacks. This lets end users easily delete all of the resources that the template created, if needed.

Deploying the template interactively:
`az stack group create --name cloud-nss-web --resource-group my_rg --template-file ./cloud-nss-web.bicep --deny-settings-mode 'none' `

Deploying the template with the .bicepparams file:

`az stack group create --name cloud-nss-web --resource-group my_rg --parameters cloud-nss-web.bicepparam --deny-settings-mode 'none'`

Deleting the template and associated resources:

`az stack group delete --name cloud-nss-web --resource-group my_rg --delete-resources`

I also constructed the feed api URL that the end user needs to enter into the Zscaler Cloud NSS feed config and provided it as an output that can be queried. This way they can just quickly copy/paste the URL:

`az stack group show -g my_rg -n cloud-nss-web --query outputs.api_url`

E.g.,

PS /home/support> az stack group show -g gleyfer_rg -n cloud-nss-web --query outputs.api_url                                                                                                                                  
{
  "type": "String",
  "value": "https://genetest-dce-web-s4cs.eastus-1.ingest.monitor.azure.com/dataCollectionRules/dcr-bb496a1f31bb4acf93a0941e970eacb8/streams/Custom-nss_web_CL?api-version=2022-06-01"
}

Also removed the depends_on check for dce by referencing the id property of the dce directly in the dcr creation (automatically takes care of the dependency and even warns you that the depends_on block is unnecessary). 